### PR TITLE
fix(quiz,ranking): persist result text; prevent null score post

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -203,8 +203,7 @@ h1 .small-title {
 /* Previously loaded after style.css; keep at end to preserve precedence. */
 /* --- hotfix: keep ranking button and result visible --- */
 #open-ranking-btn{display:inline-flex!important;visibility:visible!important;opacity:1!important}
-#quiz #result,#quiz #result-message,#quiz .result,#quiz .score,#quiz .score-message,#app #result,#app #result-message,#app .result,#app .score,#app .score-message,.quiz #result,.quiz #result-message,.quiz .result,.quiz .score,.quiz .score-message{display:block!important;visibility:visible!important;opacity:1!important}
-#quiz [hidden],#quiz .hidden,#quiz .is-hidden,#app [hidden],#app .hidden,#app .is-hidden,.quiz [hidden],.quiz .hidden,.quiz .is-hidden{display:initial!important;visibility:visible!important;opacity:1!important}
+/* Remove overlay-wide force rules; rely on in-app rendering */
 
 /* Ensure result text is visible by default */
 #score { display:block; visibility:visible; opacity:1; }


### PR DESCRIPTION
- Remove temporary HOTFIX overlay/holdoff/sessionStorage code\n- Render result text directly into #score and keep visible; gate auto-restart with RESULT_HOLD_MS (default 20s) and clear hold on explicit restart\n- Keep minimal CSS (#open-ranking-btn, #score); drop broad force rules\n- Ranking submit already normalized in previous commit to avoid null/400