### PR TITLE
fix(quiz): keep result visible until user restarts (persistent result bar)

### DIFF
--- a/js/quiz.js
+++ b/js/quiz.js
@@ -1131,3 +1131,59 @@ try {
 })();
 
 // removed HOTFIX: result overlay & sessionStorage persistence
+
+/* ---------- [Result Bar Helpers] ---------- */
+(function () {
+  function ensureResultBar() {
+    let bar = document.getElementById('result-bar');
+    if (!bar) {
+      bar = document.createElement('div');
+      bar.id = 'result-bar';
+      // インライン最小スタイル（広域CSSを汚さない）
+      bar.setAttribute('style', [
+        'position:fixed',
+        'top:0',
+        'left:0',
+        'right:0',
+        'z-index:9999',
+        'display:none',
+        'padding:10px 12px',
+        'font-size:14px',
+        'line-height:1.3',
+        'text-align:center',
+        'background:rgba(0,0,0,0.85)',
+        'color:#fff',
+        'backdrop-filter:saturate(120%) blur(6px)',
+        '-webkit-font-smoothing:antialiased',
+      ].join(';'));
+      bar.setAttribute('role', 'status');
+      bar.setAttribute('aria-live', 'polite');
+      document.body.appendChild(bar);
+    }
+    return bar;
+  }
+
+  window.showResultBar = function (text) {
+    const bar = ensureResultBar();
+    bar.textContent = text || '';
+    bar.style.display = 'block';
+    // バーで隠れないよう最小の余白を付与（重複付与防止）
+    const html = document.documentElement;
+    if (!html.hasAttribute('data-has-result-bar-padding')) {
+      const cur = parseInt(getComputedStyle(document.body).paddingTop || '0', 10);
+      document.body.style.paddingTop = (cur + 44) + 'px';
+      html.setAttribute('data-has-result-bar-padding', '1');
+    }
+  };
+
+  window.hideResultBar = function () {
+    const bar = document.getElementById('result-bar');
+    if (bar) bar.style.display = 'none';
+    const html = document.documentElement;
+    if (html && html.hasAttribute('data-has-result-bar-padding')) {
+      const cur = parseInt(getComputedStyle(document.body).paddingTop || '0', 10);
+      document.body.style.paddingTop = Math.max(0, cur - 44) + 'px';
+      html.removeAttribute('data-has-result-bar-padding');
+    }
+  };
+})();

--- a/js/quiz.js
+++ b/js/quiz.js
@@ -520,7 +520,9 @@ window.showResultText = function (text) {
 const __handleRestart = () => {
   window.__QUIZ_RESULT_HOLD__ = false;
   try { if (typeof hideResultBar === 'function') hideResultBar(); } catch(_) {}
-  loadQuiz({ force: true });
+  if (typeof loadQuiz === 'function') { loadQuiz({ force: true }); }
+  else if (typeof window.loadQuiz === 'function') { window.loadQuiz({ force: true }); }
+  else { try { location.reload(); } catch(_) {} }
 };
 
 // 既存のボタンがあればバインド。無ければ何もしない（自動注入しない）
@@ -546,13 +548,16 @@ const __handleRestart = () => {
 // Fallback: delegate restart clicks if explicit handler is not bound or markup differs
 document.addEventListener('click', (e) => {
   try {
-    const t = e.target; if (!t) return;
+    const t = e.target && (e.target.closest('button, a, [role="button"]') || e.target);
+    if (!t) return;
     const txt = (t.textContent || '').trim();
     if (t.matches('#retry, #restart, .retry, .restart, [data-restart]') || txt === 'もう一度') {
       e.preventDefault();
       window.__QUIZ_RESULT_HOLD__ = false;
       try { if (typeof hideResultBar === 'function') hideResultBar(); } catch(_) {}
-      loadQuiz({ force: true });
+      if (typeof loadQuiz === 'function') { loadQuiz({ force: true }); }
+      else if (typeof window.loadQuiz === 'function') { window.loadQuiz({ force: true }); }
+      else { try { location.reload(); } catch(_) {} }
     }
   } catch(_) {}
 }, { capture: true });


### PR DESCRIPTION
## What
- Add persistent top result bar via inline styles (#result-bar)
- Gate auto restart with __QUIZ_RESULT_HOLD__
- Unify 「もう一度」 handler to hide bar and force reload

## How
- quiz.js only; no overlay/observer/storage
- Helpers from Step1 used: ensureResultBar(), showResultBar(), hideResultBar()

## QA (PR Preview)
1) Hard reload (⌘+Shift+R)
2) Finish a quiz → result bar remains
3) Console: [RANK] POST ok
4) 「詳細ランキングを見る」 opens
5) Press 「もう一度」 → bar hides and quiz restarts

## Note
- If CORS fails on preview, add preview origin to Supabase Allowed CORS Origins temporarily.