### PR TITLE
chore(rollback): disable ranking and revert to pre-Supabase baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # アシュタンガ ヨガ アーサナクイズ — 開発・運用ハンドブック（決定版 / Supabase 版）
 
+> Rollback Note (2025-09-18)
+> 現在このブランチ（rollback/pre-supabase）では、ランキング機能を完全無効化し pre-Supabase 相当の挙動で運用しています。
+> - `window.RANKING_ENABLED = false`
+> - `js/ranking.js` はスタブが早期 return（Supabase へは一切アクセスしません）
+> - 「詳細ランキングを見る」は UI 非表示
+> 復帰する場合は `window.RANKING_ENABLED = true` に戻し、スタブの早期 return ブロックを削除してください。
+
 このファイルだけ見れば、初見の AI/Coder（=codex）でも全体を把握し、即作業できます。
 
 ---
@@ -311,4 +318,3 @@ jobs:
 
           echo "Deleted id: $NEW" >> $GITHUB_STEP_SUMMARY
 END qa-ranking.yml
-

--- a/js/config.js
+++ b/js/config.js
@@ -2,6 +2,8 @@
 window.SUPABASE_URL = typeof window.SUPABASE_URL === 'undefined' ? "https://<YOUR-PROJECT>.supabase.co" : window.SUPABASE_URL;
 window.SUPABASE_ANON_KEY = typeof window.SUPABASE_ANON_KEY === 'undefined' ? "<YOUR-ANON-KEY>" : window.SUPABASE_ANON_KEY;
 window.RANKING_TOP_LIMIT = typeof window.RANKING_TOP_LIMIT === 'undefined' ? 10 : window.RANKING_TOP_LIMIT;
+// ランキング機能フラグ（完全無効化）
+window.RANKING_ENABLED = false;
 // QA用の自動実行は本番で無効化
 window.QA_AUTOBOOT = false;
 // Result hold window (ms) default

--- a/js/quiz.js
+++ b/js/quiz.js
@@ -551,6 +551,16 @@ const __handleRestart = () => {
 
 // share button binding moved to guarded block above
 
+// Hide ranking button if ranking disabled (rollback mode)
+document.addEventListener('DOMContentLoaded', () => {
+  try {
+    if (window.RANKING_ENABLED === false) {
+      const btn = document.querySelector('#open-ranking-btn, .open-ranking, [data-open-ranking]');
+      if (btn) btn.style.display = 'none';
+    }
+  } catch (_) {}
+});
+
 // 最初のクイズをセットアップして読み込む
 setupQuiz();
 // ===== RANKING BOOTSTRAP (self-contained) =====

--- a/js/ranking.js
+++ b/js/ranking.js
@@ -1,4 +1,26 @@
 /* js/ranking.js ー ファイル全置き換え推奨 */
+// ===== RANKING DISABLED (pre-Supabase rollback) =====
+if (window.RANKING_ENABLED === false) {
+  console.log("[RANK] disabled: running in pre-Supabase rollback mode");
+  async function getTop(limit = 10) {
+    console.log("[RANK] GET (noop) → []");
+    return [];
+  }
+  async function submitScore({ name, score, total_questions, time_spent }) {
+    console.log(
+      "[RANK] POST (noop) name=%s score=%s total=%s time=%s",
+      name, score, total_questions, time_spent
+    );
+    return true;
+  }
+  window.rankingSystem = { getTop, submitScore };
+  // 以降の Supabase 初期化・通信処理は一切実行しない
+  // ===================================================
+  // ここで return してファイル末尾までスキップ
+  // ===================================================
+  // eslint-disable-next-line no-useless-return
+  return;
+}
 
 // --- Supabase client (singleton) ---
 const __SB__ =


### PR DESCRIPTION
- ランキング機能を完全無効化（スタブ化）\n- Supabase へは一切アクセスしない（ranking.js 冒頭で早期 return）\n- UI の『詳細ランキングを見る』ボタンを非表示\n- クイズ本体のみで安定稼働に戻す\n- 復帰手順: window.RANKING_ENABLED = true に戻し、スタブの早期 return を削除